### PR TITLE
fix: Handle empty input in versioning job by providing default branch

### DIFF
--- a/.github/workflows/pipe.yml
+++ b/.github/workflows/pipe.yml
@@ -114,7 +114,7 @@ jobs:
   # VERSIONING (on all configured branches)
   versioning:
     needs: [build-test, code-analyze, test, changes]
-    if: ${{ contains(fromJson(inputs.all_branches), github.ref_name) && (needs.build-test.result == 'success' || (needs.changes.result == 'success' && needs.changes.outputs.cicd == 'true')) }}
+    if: ${{ contains(fromJson(inputs.all_branches || '["main"]'), github.ref_name) && (needs.build-test.result == 'success' || (needs.changes.result == 'success' && needs.changes.outputs.cicd == 'true')) }}
     uses: ./.github/workflows/job.ci.version.yml
 
   # TAGGING (on first branch with version)


### PR DESCRIPTION
### Summary

**Type:** fix

* **What kind of change does this PR introduce?**
  * This PR introduces a bug fix in the GitHub Actions workflow configuration to handle cases where the \`inputs.all_branches\` parameter is empty.

* **What is the current behavior?**
  * Currently, if \`inputs.all_branches\` is empty, the versioning job fails because it cannot parse an empty string as JSON.

* **What is the new behavior?**
  * With this change, if \`inputs.all_branches\` is empty, it defaults to \`['main']\`, ensuring the workflow continues to function by defaulting to the main branch.

* **Does this PR introduce a breaking change?**
  * No breaking changes are introduced. Users will experience a more robust CI process, especially in scenarios where specific configurations might leave \`inputs.all_branches\` undefined.

* **Has Testing been included for this PR?
  * The change is within the CI configuration, and testing would typically involve running the modified workflow to ensure it behaves as expected under different scenarios (e.g., with \`inputs.all_branches\` being empty or populated).

### Other Information

This fix enhances the reliability of our CI/CD pipeline by ensuring that the versioning job does not fail due to configuration oversights. It's a small but critical improvement for maintaining smooth operations in automated workflows.
----